### PR TITLE
Update Dockerfile to maintained PHP version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2-cli
+FROM php:7.3-cli
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.1-cli
+FROM php:7.2-cli
 
 RUN apt-get update && \
     apt-get install -y git zip unzip && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM php:7.2-cli
 
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
 RUN apt-get update && \
     apt-get install -y git zip unzip && \
-    php -r "readfile('http://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer && \
     apt-get -y autoremove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 ## PHP-Composer
 
-This takes the latest stable official PHP Docker image (currently `php:7.1-cli`), and adds in Git, Composer, and Zip.
+This takes the latest stable official PHP Docker image (currently `php:7.3-cli`), and adds in Git, Composer, and Zip.
 
 This is best  used for when you do not have PHP 7+ installed on your machine, and don't want to install it. In such a case, you may run into a chicken and egg issue with [Vessel](https://vessel.shippingdocker.com) where you cannot start a new Laravel project, nor get [Vessel](https://vessel.shippingdocker.com), until you have PHP 7, but you won't have PHP 7 until you install and setup Vessel.
 


### PR DESCRIPTION
Laravel 6.0 requires PHP 7.2 or higher since active PHP 7.1 support will stop coming December. Using the current Dockerfile results in installing Laravel 5.8 which isn't actively maintained anymore.

Every currently maintained Laravel version (active or security) should be compatible with PHP 7.2 so this change should have little to no impact.

![afbeelding](https://user-images.githubusercontent.com/9716643/64253913-9490d900-cf1e-11e9-8751-e712067b4fcc.png)

I also changed the Dockerfile to use a `COPY` statement that just includes the official Composer image, as per their documentation. This might actually break builds, but those would be Docker installations that haven't been updated for over two years.

![afbeelding](https://user-images.githubusercontent.com/9716643/64253997-c30eb400-cf1e-11e9-9ba6-1ce405c68279.png)

