### PR TITLE
Update composer from v1 to v2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:7.4-cli
 
-COPY --from=composer /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 RUN apt-get update \
     && apt-get install -y git zip unzip zlib1g-dev libzip-dev \


### PR DESCRIPTION
We can either do this or re-trigger a build of the image since we are using composer:latest in this case.

I tried this on my Mac, and the command you have on Vessel's documentation runs much faster with composer v2:

`
docker run --rm -it \
    -v $(pwd):/opt \
    -w /opt shippingdocker/php-composer:latest \
    composer create-project laravel/laravel
`